### PR TITLE
ci: fix ghasec security alerts across all workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,12 +6,19 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
 
   e2e:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/go-fix.yml
+++ b/.github/workflows/go-fix.yml
@@ -6,11 +6,18 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   fix:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/go-releaser-check.yml
+++ b/.github/workflows/go-releaser-check.yml
@@ -6,14 +6,18 @@ on:
       - main
   pull_request:
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -5,17 +5,20 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   goreleaser:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -9,15 +9,19 @@ on:
       - main
   pull_request:
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
 
   build:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    permissions:
+      pull-requests: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,15 +5,19 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -6,15 +6,19 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   license-check:
     name: Check licenses
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,12 +8,14 @@ on:
         description: "version tag (vx.x.x)"
         required: true
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   tag_push:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -27,8 +29,11 @@ jobs:
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{github.repository}}/git/refs \
-            -f ref="refs/tags/${{inputs.tag}}" \
-            -f sha="${{github.sha}}"
+            /repos/${REPO}/git/refs \
+            -f ref="refs/tags/${TAG}" \
+            -f sha="${SHA}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+          SHA: ${{ github.sha }}


### PR DESCRIPTION
- Add top-level `permissions: {}` with job-level least-privilege grants
- Add `timeout-minutes` to all jobs
- Add `persist-credentials: false` to all checkout steps
- Fix script injection in tag.yml by using env vars instead of expressions